### PR TITLE
Fix crate features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ cfg-if = "1.0.0"
 parking_lot = "0.12.1"
 
 [features]
-default = ["std"]
 esp = ["dep:esp-idf-hal"]
 embassy = ["dep:embassy-time"]
 embedded_hal = ["dep:embedded-hal", "embedded-hal/unproven"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,8 @@ cfg-if = "1.0.0"
 parking_lot = "0.12.1"
 
 [features]
-esp = ["esp-idf-hal"]
-embassy = ["embassy-time"]
-embedded_hal = ["embedded-hal/unproven"]
+default = ["std"]
+esp = ["dep:esp-idf-hal"]
+embassy = ["dep:embassy-time"]
+embedded_hal = ["dep:embedded-hal", "embedded-hal/unproven"]
 std = []


### PR DESCRIPTION
Hi, nice work on this crate. This is the only one I have found that support double and long click detection.

When adding the dependency with `cargo add`, I noticed there were some ambiguous crate features such as `embedded_hal` and `embedded-hal`. I took a look at the manifest and I think the crate features were set up in correctly so here's a small PR to fix that. 